### PR TITLE
Improve type safety and error handling

### DIFF
--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -109,7 +109,7 @@ class FlashHelper extends Helper {
 		$result = [];
 		foreach ($order as $type) {
 			foreach ($messages as $k => $message) {
-				$messageType = $message['type'] ?? substr($message['element'], strrpos($message['element'], '/') + 1);
+				$messageType = $message['type'] ?? (($pos = strrpos($message['element'], '/')) !== false ? substr($message['element'], $pos + 1) : $message['element']);
 				if ($messageType !== $type) {
 					continue;
 				}


### PR DESCRIPTION
## Summary

This PR improves type safety throughout the Flash plugin by adding missing type hints and enhances error handling for JSON encoding operations.

### 🔒 Type Safety Improvements (Issues #1, #2, #5, #7, #9)

Added comprehensive type hints across all public and protected methods:

**Issue #1:** `beforeRedirect()` method
- Added type hints: `array|string $url`, `Response $response`

**Issue #2:** Public methods missing parameter types
- `message()`: Added `\Exception|string $message`, `array|string|null $options`
- `set()`: Added `\Exception|string $message`
- `transientMessage()`: Added `\Exception|string $message`, `array|string|null $options` + return type

**Issue #5:** `_mergeOptions()` method
- Added parameter type: `array|string|null $options`
- Simplified logic with null coalescing operator

**Issue #7:** `_transformCrudOptions()` method
- Added return type: `array`

**Issue #9:** `addFlashHeader()` method
- Added parameter type: `Response $response`

### 🛡️ Error Handling & Security (Issue #3)

**JSON Encoding Safety**
- Added `JSON_THROW_ON_ERROR` flag for proper error detection
- Implemented try-catch block to gracefully handle encoding failures
- Added XSS protection flags:
  - `JSON_HEX_TAG` - Encodes < and >
  - `JSON_HEX_AMP` - Encodes &
  - `JSON_HEX_APOS` - Encodes '
  - `JSON_HEX_QUOT` - Encodes "

These flags prevent XSS when flash message JSON is inserted into HTML/JavaScript contexts.

### 📝 Code Quality (Issue #4)

**FlashHelper Improvements**
- Fixed unsafe `strrpos()` usage with proper null checking
- Added fallback to use full element name if no '/' found
- Prevents potential substr() errors

**Code Standards**
- Added `use Cake\Http\Response` statement per PSR-2R guidelines
- Removed inline fully qualified class names from method signatures

## Testing

All quality checks pass:
- ✅ PHPUnit: 12 tests, 32 assertions
- ✅ PHPCS: Clean

## Files Changed

- `src/Controller/Component/FlashComponent.php`: Type hints, error handling, code quality
- `src/View/Helper/FlashHelper.php`: Safe array access improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)