### PR TITLE
FlashHelper type-safety symmetry pass

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,8 @@ $this->Flash->transientError('I am not persisted in session');
 $this->Flash->transientMessage('Oh oh', ['type' => 'custom']);
 ```
 
+Use `transient<Type>()` or `transientMessage()`. A bare `transient()` call is invalid and throws.
+
 Note: Do not try to add anything in the layout below the `render()` call as that would not be included anymore.
 
 If you want to just output a message anywhere in your template (like a warning block):

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -162,8 +162,10 @@ class FlashHelper extends Helper {
 		// Keep the stack at most `limit` entries even if multiple writes piled up
 		// before this call (Issue #M3 sibling — single shift wasn't enough).
 		$limit = (int)$this->getConfig('limit');
-		while ($messages && count($messages) >= $limit) {
+		$count = count($messages);
+		while ($count >= $limit) {
 			array_shift($messages);
+			$count--;
 		}
 		$messages[] = $options;
 		Configure::write('TransientFlash.' . $options['key'], $messages);

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -136,7 +136,7 @@ class FlashHelper extends Helper {
 	 *
 	 * @return string HTML
 	 */
-	public function message(string $message, $messageOptions = null, array $options = []): string {
+	public function message(string $message, array|string|null $messageOptions = null, array $options = []): string {
 		$messageOptions = $this->_mergeOptions($messageOptions);
 		$messageOptions['message'] = $message;
 
@@ -151,15 +151,18 @@ class FlashHelper extends Helper {
 	 * Add a message on the fly
 	 *
 	 * @param string $message
-	 * @param array|string|null $options
+	 * @param array<string, mixed>|string|null $options
 	 * @return void
 	 */
-	public function transientMessage(string $message, $options = null): void {
+	public function transientMessage(string $message, array|string|null $options = null): void {
 		$options = $this->_mergeOptions($options);
 		$options['message'] = $message;
 
 		$messages = (array)Configure::read('TransientFlash.' . $options['key']);
-		if ($messages && count($messages) > $this->getConfig('limit')) {
+		// Keep the stack at most `limit` entries even if multiple writes piled up
+		// before this call (Issue #M3 sibling — single shift wasn't enough).
+		$limit = (int)$this->getConfig('limit');
+		while ($messages && count($messages) >= $limit) {
 			array_shift($messages);
 		}
 		$messages[] = $options;
@@ -170,13 +173,16 @@ class FlashHelper extends Helper {
 	 * Add a message on the fly
 	 *
 	 * @param string $name name
-	 * @param array<string> $args method arguments
+	 * @param array<int, mixed> $args method arguments
 	 * @throws \BadMethodCallException
 	 * @throws \Cake\Http\Exception\InternalErrorException
 	 * @return void
 	 */
 	public function __call(string $name, array $args): void {
-		if (strpos($name, 'transient') !== 0) {
+		// Match FlashComponent::__call: the literal `transient()` is a programmer error
+		// (no type suffix) and must throw rather than silently store under type=''
+		// (Issue #M4).
+		if ($name === 'transient' || !str_starts_with($name, 'transient')) {
 			throw new BadMethodCallException('Method ' . $name . '() does not exist. Select a type, e.g. transientInfo().');
 		}
 
@@ -198,7 +204,7 @@ class FlashHelper extends Helper {
 	 *
 	 * @return array<string, mixed>
 	 */
-	protected function _mergeOptions($options): array {
+	protected function _mergeOptions(array|string|null $options): array {
 		if (!is_array($options)) {
 			$type = $options;
 			if (!$type) {
@@ -216,6 +222,12 @@ class FlashHelper extends Helper {
 		$options += $this->getConfig();
 
 		[$plugin, $element] = pluginSplit($options['element']);
+
+		// Idempotency: if the caller already passed `flash/error`, don't produce
+		// `flash/flash/error` (Issue #M5).
+		if (str_starts_with($element, 'flash/')) {
+			$element = substr($element, 6);
+		}
 
 		if ($plugin) {
 			$options['element'] = $plugin . '.flash/' . $element;

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -11,9 +11,9 @@ use TestApp\Controller\FlashComponentTestController;
 class FlashComponentTest extends TestCase {
 
 	/**
-	 * @var \TestApp\Controller\FlashComponentTestController
+	 * @var \TestApp\Controller\FlashComponentTestController|null
 	 */
-	protected $Controller;
+	protected ?FlashComponentTestController $Controller = null;
 
 	/**
 	 * @return void
@@ -34,7 +34,7 @@ class FlashComponentTest extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
-		unset($this->Controller);
+		$this->Controller = null;
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Flash\Test\TestCase\View\Helper;
 
+use BadMethodCallException;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
@@ -15,9 +16,9 @@ class FlashHelperTest extends TestCase {
 	protected array $fixtures = ['core.Sessions'];
 
 	/**
-	 * @var \Flash\View\Helper\FlashHelper
+	 * @var \Flash\View\Helper\FlashHelper|null
 	 */
-	protected $Flash;
+	protected ?FlashHelper $Flash = null;
 
 	/**
 	 * @return void
@@ -38,7 +39,7 @@ class FlashHelperTest extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
-		unset($this->Flash);
+		$this->Flash = null;
 	}
 
 	/**
@@ -107,6 +108,16 @@ class FlashHelperTest extends TestCase {
 <div class="custom-info foo">I am sth custom</div>
 ';
 		$this->assertEquals($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testTransientRequiresType(): void {
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Method transient() does not exist. Select a type, e.g. transientInfo().');
+
+		$this->Flash->transient('Missing type');
 	}
 
 }


### PR DESCRIPTION
## Summary

PR #15 typed `FlashComponent`'s public and protected methods, but the matching `FlashHelper` methods were left with bare untyped parameters relying only on docblocks. PHPStan level 8 flags these via `missingType.parameter` unless ignored, and the asymmetry was a real footgun for callers passing argument shapes the helper claimed (in docblocks) to accept.

## Changes

- **Typed signatures**: `message()`, `transientMessage()`, and `_mergeOptions()` now declare `array|string|null` parameters, matching `FlashComponent`.
- **`str_starts_with`** replaces `strpos(\$name, 'transient') === 0`. The plugin requires PHP 8.2+ so there is no compat reason to keep the old form.
- **`__call` rejects the literal `transient()`** (no type suffix) the same way `FlashComponent::__call` does. Previously the helper accepted it: `strpos('transient', 'transient') === 0` was true, then `substr('transient', 9) === ''` made the type the empty string and silently stored the message under `type => ''`, element `flash/`.
- **Idempotent `flash/` prefix** in `_mergeOptions`: callers passing a stored options array containing `'element' => 'flash/error'` previously produced `flash/flash/error` on the second pass through. Now strips a leading `flash/` before re-prefixing.
- **While-loop stack trim** in `transientMessage`: a single `array_shift` did not bring an over-limit stack back to `limit` (e.g. when `limit` was lowered, or multiple writes piled up). Mirrors the suggested fix for the same shape in `FlashComponent::_assertSessionStackSize`.
- **Docblock fix** on `__call`: `array<int, mixed> \$args` instead of `array<string>` (`\$args[1]` is an options array, not a string).

## Quality gates

- 12/12 existing tests pass
- PHPStan level 8 clean
- PHPCS clean